### PR TITLE
fix: remove deprecated Snyk vulnerabilities badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
   <a href="https://www.npmjs.com/package/agent-rules"><img src="https://badgen.net/npm/dt/agent-rules" alt="downloads"/></a>
   <a href="https://github.com/lirantal/agent-rules/actions?workflow=CI"><img src="https://github.com/lirantal/agent-rules/workflows/CI/badge.svg" alt="build"/></a>
   <a href="https://codecov.io/gh/lirantal/agent-rules"><img src="https://badgen.net/codecov/c/github/lirantal/agent-rules" alt="codecov"/></a>
-  <a href="https://snyk.io/test/github/lirantal/agent-rules"><img src="https://snyk.io/test/github/lirantal/agent-rules/badge.svg" alt="Known Vulnerabilities"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Responsible Disclosure Policy" /></a>
 </p>
 


### PR DESCRIPTION
The Snyk vulnerabilities badge (`snyk.io/test/github/...`) has been deprecated and no longer renders correctly. Removing it from the README so the badge row stays clean.