### PR TITLE
fix: pin CI status badge to default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://www.npmjs.com/package/agent-rules"><img src="https://badgen.net/npm/v/agent-rules" alt="npm version"/></a>
   <a href="https://www.npmjs.com/package/agent-rules"><img src="https://badgen.net/npm/license/agent-rules" alt="license"/></a>
   <a href="https://www.npmjs.com/package/agent-rules"><img src="https://badgen.net/npm/dt/agent-rules" alt="downloads"/></a>
-  <a href="https://github.com/lirantal/agent-rules/actions?workflow=CI"><img src="https://github.com/lirantal/agent-rules/workflows/CI/badge.svg" alt="build"/></a>
+  <a href="https://github.com/lirantal/agent-rules/actions/workflows/ci.yml"><img src="https://github.com/lirantal/agent-rules/actions/workflows/ci.yml/badge.svg?branch=main" alt="build"/></a>
   <a href="https://codecov.io/gh/lirantal/agent-rules"><img src="https://badgen.net/codecov/c/github/lirantal/agent-rules" alt="codecov"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Responsible Disclosure Policy" /></a>
 </p>


### PR DESCRIPTION
The CI status badge in the README currently points to the unpinned workflow URL, which can show the status of any branch (e.g. PR runs) rather than the default branch. Pinning the badge to the repository default branch so it consistently reflects mainline CI.