### PR TITLE
docs: add repository context docs 🤖🤖🤖

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,19 +6,30 @@ Guidance for AI coding agents working in this repository.
 
 Before making changes, read:
 
-- `CONTRIBUTING.md` for PR expectations, tests, changesets, commit style, and agent-specific rules.
-- `RELEASE.md` for changeset and release workflow details.
-- `README.md` and relevant docs for user-facing behavior and project context.
+- `CONTRIBUTING.md` for contribution, PR, testing, commit, and agent-specific expectations.
+- `RELEASE.md` for release workflow details.
+- `README.md` for user-facing behavior, install/use examples, and package or app overview.
+- `docs/README.md` for the project documentation index.
+- `docs/development.md` for local setup and development workflows.
+- `docs/testing.md` for test strategy, commands, and verification expectations.
+- `docs/architecture.md` for project structure, boundaries, and important invariants.
+- `docs/conventions.md` for project-specific coding, documentation, and maintenance conventions.
 
 Treat those files as the source of truth. Do not duplicate or reinterpret their rules here.
 
-## Changesets
+## Documentation
 
-Before opening a PR, check `CONTRIBUTING.md#changesets`.
-Follow `RELEASE.md` for changeset creation steps.
+- Keep documentation in sync when changing behavior, public interfaces, workflows, architecture, configuration, or operational assumptions.
+- Put project-specific development details in `docs/`; keep root files focused on their standard audiences.
+- Prefer linking to the source of truth over duplicating long instructions across files.
+- When adding new docs, link them from `docs/README.md` and update this file only when they become important entry points for future agents.
 
 ## PRs and Issues
 
-Follow the agent labeling/title rules in `CONTRIBUTING.md`.
+- Follow PR, issue, and agent-labeling rules in `CONTRIBUTING.md`.
+- Use the issue-linking format specified in `CONTRIBUTING.md`.
 
-Use the issue-linking format specified in `CONTRIBUTING.md`.
+## Releases
+
+- Follow `RELEASE.md` for release workflow and changeset creation steps.
+- If this project uses changesets, treat `RELEASE.md` and any changeset guidance in `CONTRIBUTING.md` as authoritative.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Current category of rules available:
 - Security vulnerabilities, based on [Snyk.io](https://snyk.io/)
 - Testing strategy and test code guidelines, built from [Yoni Goldberg's JavaScript Testing](https://github.com/goldbergyoni/javascript-testing-best-practices) and Liran Tal's testing strategy
 
+## Documentation
+
+- [Project documentation](./docs/README.md) - development, testing, architecture, and conventions.
+
 ## Contributing
 
 Please consult [CONTRIBUTING](./CONTRIBUTING.md) for guidelines on contributing to this project.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# agent-rules Documentation
+
+This directory contains project documentation for maintainers and coding agents.
+
+## Core Docs
+
+- [Development](./development.md) - local setup, workflows, and useful commands.
+- [Testing](./testing.md) - test commands, test organization, and verification expectations.
+- [Architecture](./architecture.md) - repository structure, package boundaries, and important flows.
+- [Conventions](./conventions.md) - coding, documentation, and maintenance conventions.
+
+## Root References
+
+- [Project README](../README.md) - user-facing overview, installation, and usage.
+- [Contributing](../CONTRIBUTING.md) - issue, PR, commit, and agent expectations.
+- [Release](../RELEASE.md) - Changesets and release workflow.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,18 @@
+# Architecture
+
+## Overview
+
+agent-rules package description: Rules and instructions for agentic coding tools like Cursor, Claude CLI, Gemini CLI, Qodo, Cline and more.
+
+## Repository Structure
+
+- `package.json` - root package scripts and dependency metadata.
+- `.changeset/` - Changesets configuration and pending release notes.
+- `docs/` - project documentation for maintainers and coding agents.
+
+## Boundaries
+
+- Keep user-facing usage, installation, and examples in the root `README.md`.
+- Keep contribution rules in `CONTRIBUTING.md`.
+- Keep release workflow details in `RELEASE.md`.
+- Keep deeper development and architecture notes in `docs/`.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,20 @@
+# Conventions
+
+## Commits and PRs
+
+- Use Conventional Commits for commit messages.
+- Keep PRs focused on one logical change.
+- Include a Changeset for release-worthy package behavior changes.
+- Agent-authored PRs should follow the repository's agent title marker guidance in `CONTRIBUTING.md`.
+
+## Documentation
+
+- Keep root `README.md` focused on users and package consumers.
+- Put maintainer and agent context in `docs/`.
+- Link new documentation from `docs/README.md`.
+
+## Code
+
+- Prefer the existing package structure and scripts over introducing new tooling.
+- Keep generated files, dependency folders, and build output out of commits.
+- Match formatting and lint expectations already configured in the repository.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,22 @@
+# Development
+
+## Prerequisites
+
+- Node.js compatible with this repository's packages and tooling.
+- npm for dependency installation and scripts.
+
+## Setup
+
+```sh
+npm install
+```
+
+## Common Commands
+
+- `pnpm build` - builds the project.
+- `pnpm lint` - runs lint checks.
+- `pnpm test` - runs the test suite.
+
+## Repository Notes
+
+This repository is organized around the root package `agent-rules`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,31 @@
+# Testing
+
+## Test Command
+
+Run the test suite with:
+
+```sh
+npm run test
+```
+
+## Linting
+
+Run lint checks with:
+
+```sh
+npm run lint
+```
+
+## Markdown
+
+Run Markdown linting with:
+
+```sh
+npm run lint:markdown
+```
+
+## Expectations
+
+- Add or update tests for behavior changes.
+- Run the relevant package-level checks before opening a PR.
+- Keep generated coverage, build output, and dependency folders out of commits.


### PR DESCRIPTION
Adds standardized repository context for coding agents and maintainers:

- refreshes AGENTS.md with the shared routing template
- adds or links canonical docs for development, testing, architecture, and conventions
- adds RELEASE.md where missing for Changesets release guidance

No package behavior changes are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds repository docs for maintainers and coding agents, including development, testing, architecture, and conventions under `docs/`. Updates `AGENTS.md` to point to these sources and links them from `README.md`; no package behavior changes.

<sup>Written for commit 82f30fdd3c159badfb8c3a3d27280afab170a2fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/agent-rules/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

