### PR TITLE
fix: resolve TypeScript imports in ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,6 +30,9 @@ export default defineConfig([
       'n/no-unsupported-features': 'off',
       'n/no-unsupported-features/node-builtins': ['error', { ignores: ['util.styleText'] }],
       'n/no-unpublished-require': 'off',
+      'n/no-missing-import': ['error', {
+        typescriptExtensionMap: [['.ts', '.js'], ['.tsx', '.js']]
+      }],
       'security/detect-non-literal-fs-filename': 'off',
       'security/detect-unsafe-regex': 'error',
       'security/detect-buffer-noassert': 'error',


### PR DESCRIPTION
The grouped dev-dependency update raises eslint-plugin-n to v18, whose no-missing-import rule needs the repository’s .js-to-.ts import mapping. Configure the supported TypeScript extension map so lint accepts NodeNext TypeScript imports. Verified with npm ci and npm run lint in Node 24.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure `eslint-plugin-n` v18 to accept NodeNext TypeScript imports by mapping .ts/.tsx to .js in the `n/no-missing-import` rule. This fixes false missing-import errors and restores passing lint on Node 24.

<sup>Written for commit 3da53717e6f9ce38b17740b437897c8346a5bfc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/agent-rules/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

